### PR TITLE
split_emails function added, test added

### DIFF
--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -175,6 +175,7 @@ NO_QUOT_LINE = re.compile('^[^>].*[\S].*')
 # Regular expression to identify if a line is a header.
 RE_HEADER = re.compile(": ")
 
+
 def extract_from(msg_body, content_type='text/plain'):
     try:
         if content_type == 'text/plain':

--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -463,17 +463,14 @@ def split_emails(msg):
 
     Return the corrected markers
     """
-    print "Conal's split_email method!"
     delimiter = get_delimiter(msg)
     msg_body = preprocess(msg, delimiter)
     # don't process too long messages
     lines = msg_body.splitlines()[:MAX_LINES_COUNT]
     markers = mark_message_lines(lines)
-    print "Conal's split_email method obtained initial markers: " + markers
     # we don't want splitlines in header blocks
     markers = correct_splitlines_in_headers(markers, lines)
 
-    print "Conal's split_email method returning corrected markers: " + markers
     return markers
 
 

--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -485,17 +485,13 @@ def _correct_splitlines_in_headers(markers, lines):
         # Only set in_header_block flag true when we hit an 's' and the line is a header.
         if m == 's':
             if not in_header_block:
-                if i == 0:
+                if bool(re.search(RE_HEADER, lines[i])):
                     in_header_block = True
-                elif i > 0 and not bool(re.search(RE_HEADER, lines[i-1])):
-                    in_header_block = True
-                else:
-                    m = 't'
             else:
                 m = 't'
 
         # If the line is not a header line, set in_header_block false.
-        if not m == 's' and not bool(re.search(RE_HEADER, lines[i])):
+        if not bool(re.search(RE_HEADER, lines[i])):
             in_header_block = False
 
         # Add the marker to the new updated markers string.

--- a/tests/text_quotations_test.py
+++ b/tests/text_quotations_test.py
@@ -696,3 +696,23 @@ def test_standard_replies():
                 "'%(reply)s' != %(stripped)s for %(fn)s" % \
                 {'reply': reply_text, 'stripped': stripped_text,
                  'fn': filename}
+
+
+def test_split_email():
+    msg = """From: Mr. X
+Date: 24 February 2016
+To: Mr. Y
+Subject: Hi
+Attachments: none
+Goodbye.
+From: Mr. Y
+To: Mr. X
+Date: 24 February 2016
+Subject: Hi
+Attachments: none
+
+Hello.
+"""
+    expected_markers = "stttttsttttet"
+    markers = quotations.split_emails(msg)
+    eq_(markers, expected_markers)

--- a/tests/text_quotations_test.py
+++ b/tests/text_quotations_test.py
@@ -712,7 +712,11 @@ Subject: Hi
 Attachments: none
 
 Hello.
+
+-- Original Message --
+On 24th February 2016 at 09.32am Conal Wrote:
+Hey!
 """
-    expected_markers = "stttttsttttet"
+    expected_markers = "stttttsttttetestt"
     markers = quotations.split_emails(msg)
     eq_(markers, expected_markers)


### PR DESCRIPTION
A new `split_emails` function has been added to `quotations.py`. This marks lines of an email thread returning the markers as a string with each character representing a line. The markers are post-processed to remove split lines inside header blocks.

Header lines are identified by the regular expression `RE_HEADER = ": "`. If the current line is a split line, it checks if the previous line is a header line. If true, it changes this line to a content line (`"t"`).

TODO: remove print lines for debugging when I observe it working.